### PR TITLE
fix: awk select correct column if some packages are installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ clean :
 
 TL_PACKAGES.lst :
 	@zypper se  texlive | \
-    awk '/texlive/ && !/texlive-dummy/ && !/texlive-config/ && $$2 !~ /debug/ \
+    awk -F '|' '/texlive/ && !/texlive-dummy/ && !/texlive-config/ && $$2 !~ /debug/ \
     {print $$2}' | uniq > $@
 
 $(NAME).spec : TL_PACKAGES.lst


### PR DESCRIPTION
awk uses `$2` to print the second _word_ of each line of `zypper search
texlive` output. If some packages are installed, the first column
contains `i` and the second _word_ will be `|`. If the field separator
is set to `-F '|'`, awk prints the second _column_ containing the
package name.
