### PR TITLE
Bump to TeX Live 2016; support non-default installation locations

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,3 @@
-Permission is granted to copy, distribute and/or modify this software under the terms of the LaTeX Project Public License (LPPL), version 1.3. The LPPL maintenance status of this software is "maintained".
+Permission is granted to copy, distribute and/or modify this software
+under the terms of the LaTeX Project Public License (LPPL), version
+1.3. The LPPL maintenance status of this software is "maintained".

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ openSUSE TeX Live packages without installing the real files. This \
 makes it possible to install the original TeX Live distribution \
 (http://www.tug.org/texlive/) without the overhead of the openSUSE \
 packages. The "dummy-package" provides scripts in "/etc/profile.d/" \
-for setting the correct pathes of the TeX Live binaries (you should \
+for setting the correct paths of the TeX Live binaries (you should \
 use the default installation path "/usr/local/texlive/"). After \
 installing a new-year "dummy-package" uninstall the previous one.'
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ init : $(NAME).spec README zzz-texlive.sh zzz-texlive.csh
 	@cp $+ $(BUILD_ROOT)/SOURCES
 
 clean :
-	@rm -rf $(BUILD_ROOT) zzz-texlive.sh zzz-texlive.csh TL_PACKAGES.lst
+	@rm -rf $(BUILD_ROOT) zzz-texlive.sh zzz-texlive.csh TL_PACKAGES.lst README $(NAME).spec $(NAME)-$(VERSION)-$(RELEASE).noarch.rpm
 
 TL_PACKAGES.lst :
 	@zypper se  texlive | \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 
 # Rolf Niepraschk, Rolf.Niepraschk@gmx.de
 
+# If you have TeX Live installed somewhere other than the default
+# location, change this variable accordingly
+TL_PATH = /usr/local/texlive
+
 NAME = texlive-dummy
 YEAR = 2016
 VERSION = $(YEAR).9999
@@ -13,9 +17,10 @@ DESCRIPTION = \
 \nmakes it possible to install the original TeX Live distribution\
 \n(http://www.tug.org/texlive/) without the overhead of the openSUSE\
 \npackages. The "dummy-package" provides scripts in "/etc/profile.d/"\
-\nfor setting the correct paths of the TeX Live binaries (you should\
-\nuse the default installation path "/usr/local/texlive/"). After\
-\ninstalling a new-year "dummy-package" uninstall the previous one.'
+\nfor setting the correct paths of the TeX Live binaries (assuming\
+\nthe installation path "'$(TL_PATH)'").\
+\n\nAfter installing a new-year "dummy-package", uninstall the previous\
+\none.'
 
 BUILD_ROOT = $(PWD)/rpmbuild
 
@@ -44,17 +49,17 @@ README :
 	@echo "======================" >> $@
 	@echo "" >> $@
 	@echo -e $(DESCRIPTION)\
-    "\nSee also: https://github.com/rolfn/texlive-dummy-opensuse" >> $@
+    "\n\nSee also: https://github.com/rolfn/texlive-dummy-opensuse" >> $@
 	@echo "" >> $@
 	@cat LICENSE >> $@
 	@echo "" >> $@
 	@echo "Rolf Niepraschk, Rolf.Niepraschk@gmx.de, $(DATE)" >> $@
 
 zzz-texlive.sh : zzz-texlive-tpl.sh
-	@cat $< | sed 's/TL_VERSION/$(YEAR)/g' > $@
+	@cat $< | sed 's/TL_VERSION/$(YEAR)/g;s/TL_PATH/$(subst /,\/,$(TL_PATH))/g;' > $@
 
 zzz-texlive.csh : zzz-texlive-tpl.csh
-	@cat $< | sed 's/TL_VERSION/$(YEAR)/g' > $@
+	@cat $< | sed 's/TL_VERSION/$(YEAR)/g;s/TL_PATH/$(subst /,\/,$(TL_PATH))/g;' > $@
 
 init : $(NAME).spec README zzz-texlive.sh zzz-texlive.csh
 	@mkdir -p $(BUILD_ROOT)/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 # Rolf Niepraschk, Rolf.Niepraschk@gmx.de
 
 NAME = texlive-dummy
-YEAR = 2015
+YEAR = 2016
 VERSION = $(YEAR).9999
-RELEASE = 5
-DATE = "2016/01/04"
+RELEASE = 6
+DATE = "2016/06/05"
 
 DESCRIPTION = \
 'This is a "dummy-package" which achieves the dependencies of the \

--- a/Makefile
+++ b/Makefile
@@ -8,14 +8,14 @@ RELEASE = 6
 DATE = "2016/06/05"
 
 DESCRIPTION = \
-'This is a "dummy-package" which achieves the dependencies of the \
-openSUSE TeX Live packages without installing the real files. This \
-makes it possible to install the original TeX Live distribution \
-(http://www.tug.org/texlive/) without the overhead of the openSUSE \
-packages. The "dummy-package" provides scripts in "/etc/profile.d/" \
-for setting the correct paths of the TeX Live binaries (you should \
-use the default installation path "/usr/local/texlive/"). After \
-installing a new-year "dummy-package" uninstall the previous one.'
+'This is a "dummy-package" which achieves the dependencies of the\
+\nopenSUSE TeX Live packages without installing the real files. This\
+\nmakes it possible to install the original TeX Live distribution\
+\n(http://www.tug.org/texlive/) without the overhead of the openSUSE\
+\npackages. The "dummy-package" provides scripts in "/etc/profile.d/"\
+\nfor setting the correct paths of the TeX Live binaries (you should\
+\nuse the default installation path "/usr/local/texlive/"). After\
+\ninstalling a new-year "dummy-package" uninstall the previous one.'
 
 BUILD_ROOT = $(PWD)/rpmbuild
 
@@ -33,7 +33,7 @@ README.md :
 	@echo "texlive-dummy-opensuse" > $@
 	@echo "======================" >> $@
 	@echo "" >> $@
-	@echo $(DESCRIPTION) >> $@
+	@echo -e $(DESCRIPTION) >> $@
 	@echo "" >> $@
 	@cat LICENSE >> $@
 	@echo "" >> $@
@@ -43,8 +43,8 @@ README :
 	@echo "texlive-dummy-opensuse" > $@
 	@echo "======================" >> $@
 	@echo "" >> $@
-	@echo $(DESCRIPTION)\
-    "See also: https://github.com/rolfn/texlive-dummy-opensuse" >> $@
+	@echo -e $(DESCRIPTION)\
+    "\nSee also: https://github.com/rolfn/texlive-dummy-opensuse" >> $@
 	@echo "" >> $@
 	@cat LICENSE >> $@
 	@echo "" >> $@

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ This is a "dummy-package" which achieves the dependencies of the openSUSE TeX Li
 
 Permission is granted to copy, distribute and/or modify this software under the terms of the LaTeX Project Public License (LPPL), version 1.3. The LPPL maintenance status of this software is "maintained".
 
-Rolf Niepraschk, Rolf.Niepraschk@gmx.de, 2014/08/14
+Rolf Niepraschk, Rolf.Niepraschk@gmx.de, 2016/06/05

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 texlive-dummy-opensuse
 ======================
 
-This is a "dummy-package" which achieves the dependencies of the openSUSE TeX Live packages without installing the real files. This makes it possible to install the original TeX Live distribution (http://www.tug.org/texlive/) without the overhead of the openSUSE packages. The "dummy-package" provides scripts in "/etc/profile.d/" for setting the correct pathes of the TeX Live binaries (you should use the default installation path "/usr/local/texlive/"). After installing a new-year "dummy-package" uninstall the previous one.
+This is a "dummy-package" which achieves the dependencies of the openSUSE TeX Live packages without installing the real files. This makes it possible to install the original TeX Live distribution (http://www.tug.org/texlive/) without the overhead of the openSUSE packages. The "dummy-package" provides scripts in "/etc/profile.d/" for setting the correct paths of the TeX Live binaries (you should use the default installation path "/usr/local/texlive/"). After installing a new-year "dummy-package" uninstall the previous one.
 
 Permission is granted to copy, distribute and/or modify this software under the terms of the LaTeX Project Public License (LPPL), version 1.3. The LPPL maintenance status of this software is "maintained".
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
 texlive-dummy-opensuse
 ======================
 
-This is a "dummy-package" which achieves the dependencies of the openSUSE TeX Live packages without installing the real files. This makes it possible to install the original TeX Live distribution (http://www.tug.org/texlive/) without the overhead of the openSUSE packages. The "dummy-package" provides scripts in "/etc/profile.d/" for setting the correct paths of the TeX Live binaries (you should use the default installation path "/usr/local/texlive/"). After installing a new-year "dummy-package" uninstall the previous one.
+This is a "dummy-package" which achieves the dependencies of the 
+openSUSE TeX Live packages without installing the real files. This 
+makes it possible to install the original TeX Live distribution 
+(http://www.tug.org/texlive/) without the overhead of the openSUSE 
+packages. The "dummy-package" provides scripts in "/etc/profile.d/" 
+for setting the correct paths of the TeX Live binaries (assuming 
+the installation path "/usr/local/texlive"). 
 
-Permission is granted to copy, distribute and/or modify this software under the terms of the LaTeX Project Public License (LPPL), version 1.3. The LPPL maintenance status of this software is "maintained".
+After installing a new-year "dummy-package", uninstall the previous 
+one.
+
+Permission is granted to copy, distribute and/or modify this software
+under the terms of the LaTeX Project Public License (LPPL), version
+1.3. The LPPL maintenance status of this software is "maintained".
 
 Rolf Niepraschk, Rolf.Niepraschk@gmx.de, 2016/06/05

--- a/zzz-texlive-tpl.csh
+++ b/zzz-texlive-tpl.csh
@@ -2,7 +2,7 @@
 #    /etc/profile.d/zzz-texlive.csh 
 #
 
-set TL_DIR="/usr/local/texlive/TL_VERSION"
+set TL_DIR="TL_PATH/TL_VERSION"
 
 set arch=`arch`
 switch ( $arch )

--- a/zzz-texlive-tpl.sh
+++ b/zzz-texlive-tpl.sh
@@ -2,7 +2,7 @@
 #    /etc/profile.d/zzz-texlive.sh 
 #
 
-TL_DIR="/usr/local/texlive/TL_VERSION"
+TL_DIR="TL_PATH/TL_VERSION"
 
 arch=`arch`
 case $arch in


### PR DESCRIPTION
This pull request fixes some spelling and formatting issues in the texlive-dummy-opensuse documentation, bumps the year for TeX Live 2016, and adds support for TeX Live installations located somewhere other than `/usr/local/share/texlive`.